### PR TITLE
Improve mobile nav scroll fade with CSS mask

### DIFF
--- a/components/navigation.vue
+++ b/components/navigation.vue
@@ -92,11 +92,11 @@ onMounted(() => {
   position: absolute;
   inset-inline: 0;
   top: 0;
-  /* Solid fill through sticky nav (top-4 + pills), soft fade below */
-  height: 4.5rem;
+  /* Solid fill through sticky nav (top-4 + pills), short fade below */
+  height: 3.75rem;
   background-color: white;
-  -webkit-mask-image: linear-gradient(to bottom, #000 0%, #000 72%, transparent 100%);
-  mask-image: linear-gradient(to bottom, #000 0%, #000 72%, transparent 100%);
+  -webkit-mask-image: linear-gradient(to bottom, #000 0%, #000 85%, transparent 100%);
+  mask-image: linear-gradient(to bottom, #000 0%, #000 85%, transparent 100%);
   mask-repeat: no-repeat;
   -webkit-mask-repeat: no-repeat;
   mask-size: 100% 100%;

--- a/components/navigation.vue
+++ b/components/navigation.vue
@@ -92,10 +92,11 @@ onMounted(() => {
   position: absolute;
   inset-inline: 0;
   top: 0;
-  height: 4rem;
+  /* Solid fill through sticky nav (top-4 + pills), soft fade below */
+  height: 4.5rem;
   background-color: white;
-  -webkit-mask-image: linear-gradient(to bottom, #000 0%, transparent 100%);
-  mask-image: linear-gradient(to bottom, #000 0%, transparent 100%);
+  -webkit-mask-image: linear-gradient(to bottom, #000 0%, #000 72%, transparent 100%);
+  mask-image: linear-gradient(to bottom, #000 0%, #000 72%, transparent 100%);
   mask-repeat: no-repeat;
   -webkit-mask-repeat: no-repeat;
   mask-size: 100% 100%;

--- a/components/navigation.vue
+++ b/components/navigation.vue
@@ -2,15 +2,13 @@
   <div class="contents xs:block self-start">
     <div ref="sentinel" class="xs:hidden h-px w-full" aria-hidden="true" />
     <div
-      aria-hidden="true"
-      :class="[
-        'pointer-events-none fixed inset-x-0 top-0 z-40 h-16 overflow-hidden transition-opacity duration-200 ease-out xs:hidden',
-        isStuck ? 'opacity-100' : 'opacity-0',
-      ]">
+      class="pointer-events-none fixed inset-x-0 top-0 z-40 h-0 overflow-visible xs:hidden"
+      aria-hidden="true">
       <div
-        class="absolute inset-0 backdrop-blur-md [mask-image:linear-gradient(to_bottom,black_0%,black_62%,transparent_100%)] [-webkit-mask-image:linear-gradient(to_bottom,black_0%,black_62%,transparent_100%)]" />
-      <div
-        class="absolute inset-0 [background:linear-gradient(to_bottom,white_0%,white_50%,rgba(255,255,255,0)_100%)] dark:[background:linear-gradient(to_bottom,var(--color-neutral-950)_0%,var(--color-neutral-950)_50%,rgba(3,7,18,0)_100%)]" />
+        :class="[
+          'nav-scroll-fade',
+          { 'nav-scroll-fade--visible': isStuck && !supportsScrollTimeline },
+        ]" />
     </div>
     <nav
       class="sticky top-4 z-50 -ml-1 mb-12 flex w-[calc(100%+8px)] gap-2 self-start xs:static xs:ml-0 xs:mb-0 xs:w-auto">
@@ -37,6 +35,7 @@ const showLifeNav = true;
 const route = useRoute();
 const sentinel = ref(null);
 const isStuck = ref(false);
+const supportsScrollTimeline = ref(false);
 
 const navItems = computed(() => {
   const items = [
@@ -66,6 +65,8 @@ const activeColorClass = computed(() => {
 onMounted(() => {
   if (!import.meta.client || !sentinel.value) return;
 
+  supportsScrollTimeline.value = CSS.supports("animation-timeline", "scroll()");
+
   const observer = new IntersectionObserver(
     ([entry]) => {
       isStuck.value = !entry.isIntersecting;
@@ -79,3 +80,55 @@ onMounted(() => {
   });
 });
 </script>
+
+<style scoped>
+@reference "~/assets/css/main.css";
+
+/*
+ * Mask-based top fade: solid page background clipped by a gradient mask
+ * (replaces stacked semi-transparent gradients + backdrop-blur).
+ */
+.nav-scroll-fade {
+  position: absolute;
+  inset-inline: 0;
+  top: 0;
+  height: 4rem;
+  background-color: white;
+  -webkit-mask-image: linear-gradient(to bottom, #000 0%, transparent 100%);
+  mask-image: linear-gradient(to bottom, #000 0%, transparent 100%);
+  mask-repeat: no-repeat;
+  -webkit-mask-repeat: no-repeat;
+  mask-size: 100% 100%;
+  -webkit-mask-size: 100% 100%;
+}
+
+:global(.dark) .nav-scroll-fade {
+  background-color: var(--color-neutral-950);
+}
+
+@supports (animation-timeline: scroll()) {
+  .nav-scroll-fade {
+    opacity: 0;
+    animation: nav-scroll-fade-in linear both;
+    animation-timeline: scroll(root block);
+    animation-range: 0 1rem;
+  }
+
+  @keyframes nav-scroll-fade-in {
+    to {
+      opacity: 1;
+    }
+  }
+}
+
+@supports not (animation-timeline: scroll()) {
+  .nav-scroll-fade {
+    opacity: 0;
+    transition: opacity 200ms ease-out;
+  }
+
+  .nav-scroll-fade--visible {
+    opacity: 1;
+  }
+}
+</style>

--- a/components/navigation.vue
+++ b/components/navigation.vue
@@ -92,11 +92,27 @@ onMounted(() => {
   position: absolute;
   inset-inline: 0;
   top: 0;
-  /* Solid fill through sticky nav (top-4 + pills), short fade below */
-  height: 3.75rem;
+  /* Solid through nav, then a longer eased ramp (no hard jump to full white) */
+  height: 4rem;
   background-color: white;
-  -webkit-mask-image: linear-gradient(to bottom, #000 0%, #000 85%, transparent 100%);
-  mask-image: linear-gradient(to bottom, #000 0%, #000 85%, transparent 100%);
+  -webkit-mask-image: linear-gradient(
+    to bottom,
+    #000 0%,
+    #000 75%,
+    rgba(0, 0, 0, 0.88) 80%,
+    rgba(0, 0, 0, 0.62) 87%,
+    rgba(0, 0, 0, 0.3) 94%,
+    transparent 100%
+  );
+  mask-image: linear-gradient(
+    to bottom,
+    #000 0%,
+    #000 75%,
+    rgba(0, 0, 0, 0.88) 80%,
+    rgba(0, 0, 0, 0.62) 87%,
+    rgba(0, 0, 0, 0.3) 94%,
+    transparent 100%
+  );
   mask-repeat: no-repeat;
   -webkit-mask-repeat: no-repeat;
   mask-size: 100% 100%;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reworks the mobile-only top scroll fade on the navigation bar, inspired by the mask-based scroll fade patterns shared recently (solid fill + gradient mask, scroll-linked opacity).

## What changed

- **Removed** the dual-layer approach (backdrop-blur + semi-transparent white gradient stops), which could look muddy or banded on some devices.
- **Added** a single full-width layer using the page background color (`white` / `neutral-950` in dark mode) with a `mask-image` linear gradient — the fade is the mask edge, not stacked alpha gradients.
- **Scroll-linked reveal** (progressive enhancement): where `animation-timeline: scroll()` is supported, fade opacity tracks document scroll over the first `1rem` instead of snapping on/off.
- **Fallback**: IntersectionObserver + opacity transition for browsers without scroll-driven animations (unchanged trigger threshold).

## How to test

1. Open the preview on a viewport below `520px` (`xs` breakpoint).
2. Scroll down on About / Work / Life — content under the sticky nav should soften into the page background more cleanly than before.
3. At the very top, the fade should be invisible; it should ease in as you scroll (modern browsers) or fade in after ~16px (fallback).

## Notes

- Desktop nav is unchanged (`xs:hidden` on the fade layer).
- No new dependencies.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5ae2a700-6801-462a-9932-fabd6c456991"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5ae2a700-6801-462a-9932-fabd6c456991"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

